### PR TITLE
Memory fix

### DIFF
--- a/CameraViewer/MainWindow.xaml.cs
+++ b/CameraViewer/MainWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using CameraViewer.Types;
+using LibVLCSharp.WPF;
 
 namespace CameraViewer
 {
@@ -10,7 +11,17 @@ namespace CameraViewer
     /// </summary>
     public partial class MainWindow : Window
     {
+        /// <summary>
+        /// A List of all the camera players and their connections.
+        /// <para>Note: The cameras in this list must have their Dispose() methods called when they are removed.</para>
+        /// </summary>
         List<Camera> _Cameras = new();
+
+        /// <summary>
+        /// A List of all the video views used to display the cameras.
+        /// <para>Note: The video views in this list must have their Dispose() methods called when they are removed.</para>
+        /// </summary>
+        List<VideoView> _VideoViews = new();
 
         /// <summary>
         /// Initialize the Main Window.
@@ -47,7 +58,20 @@ namespace CameraViewer
         {
             if (newCamera != null)
             {
-                CameraPanel.Children.Add(newCamera.VideoView());
+                // Create new video view.
+                var newVidView = new VideoView()
+                {
+                    MediaPlayer = newCamera.VlcPlayer,
+                    MinHeight = 200,
+                    MinWidth = 200
+                };
+
+                // Add to the video views list.
+                _VideoViews.Add(newVidView);
+
+                // Add to the UI.
+                CameraPanel.Children.Add(newVidView);
+
                 newCamera.Play();
             }
         }
@@ -57,10 +81,17 @@ namespace CameraViewer
         /// </summary>
         internal void RefreshCameras()
         {
-            // Removes all cameras from the UI.
+            // Remove all video views from the UI.
             CameraPanel.Children.Clear();
 
-            // Removes all cameras from memory.
+            // Dispose all the video views from memory.
+            foreach (VideoView vidview in _VideoViews)
+                vidview.Dispose();
+
+            // Remove all the video views from the list.
+            _VideoViews.Clear();
+
+            // Remove all cameras from memory.
             _Cameras.Clear();
 
             // Read the camera info from the XML file.

--- a/CameraViewer/MainWindow.xaml.cs
+++ b/CameraViewer/MainWindow.xaml.cs
@@ -2,7 +2,6 @@
 using System.Windows;
 using System.Windows.Controls;
 using CameraViewer.Types;
-using LibVLCSharp.WPF;
 
 namespace CameraViewer
 {
@@ -16,12 +15,6 @@ namespace CameraViewer
         /// <para>Note: The cameras in this list must have their Dispose() methods called when they are removed.</para>
         /// </summary>
         List<Camera> _Cameras = new();
-
-        /// <summary>
-        /// A List of all the video views used to display the cameras.
-        /// <para>Note: The video views in this list must have their Dispose() methods called when they are removed.</para>
-        /// </summary>
-        List<VideoView> _VideoViews = new();
 
         /// <summary>
         /// Initialize the Main Window.
@@ -58,19 +51,8 @@ namespace CameraViewer
         {
             if (newCamera != null)
             {
-                // Create new video view.
-                var newVidView = new VideoView()
-                {
-                    MediaPlayer = newCamera.VlcPlayer,
-                    MinHeight = 200,
-                    MinWidth = 200
-                };
-
-                // Add to the video views list.
-                _VideoViews.Add(newVidView);
-
-                // Add to the UI.
-                CameraPanel.Children.Add(newVidView);
+                // Add camera video view to the UI.
+                CameraPanel.Children.Add(newCamera.VidView);
 
                 newCamera.Play();
             }
@@ -84,12 +66,13 @@ namespace CameraViewer
             // Remove all video views from the UI.
             CameraPanel.Children.Clear();
 
-            // Dispose all the video views from memory.
-            foreach (VideoView vidview in _VideoViews)
-                vidview.Dispose();
-
-            // Remove all the video views from the list.
-            _VideoViews.Clear();
+            // Stop the camera streams and dispose their players and views.
+            foreach (var camera in _Cameras)
+            {
+                camera.Stop();
+                camera.VlcPlayer.Dispose();
+                camera.VidView.Dispose();
+            }
 
             // Remove all cameras from memory.
             _Cameras.Clear();

--- a/CameraViewer/Types/Camera.cs
+++ b/CameraViewer/Types/Camera.cs
@@ -1,11 +1,11 @@
 ﻿using LibVLCSharp.Shared;
 using LibVLCSharp.WPF;
-using System.Windows;
 
 namespace CameraViewer.Types
 {
     /// <summary>
     /// A class for setting up cameras to view in the window.
+    /// <para>Note: When done using a Camera object you must call the VlcPlayer's dispose method as well as the VidView's dispose method to avoid memory leaks.</para>
     /// </summary>
     internal class Camera
     {
@@ -21,13 +21,15 @@ namespace CameraViewer.Types
 
         /// <summary>
         /// The media player used by VLC to play the stream.
+        /// <para>Note: When done using this player you must call its dispose method.</para>
         /// </summary>
         public MediaPlayer VlcPlayer { get; }
 
         /// <summary>
         /// The view used to display the stream.
+        /// <para>Note: When done using this video view you must call its dispose method.</para>
         /// </summary>
-        //VideoView VidView { get; }
+        public VideoView VidView { get; }
 
         /// <summary>
         /// The Camera class constructor.
@@ -39,33 +41,13 @@ namespace CameraViewer.Types
             Name = name;
             ConnectionString = conString;
             VlcPlayer = new MediaPlayer(Globals.CameraLibVLC);
-            //VidView = new VideoView()
-            //{
-            //    MediaPlayer = VlcPlayer,
-            //    MinHeight = 200,
-            //    MinWidth = 200
-            //};
+            VidView = new VideoView()
+            {
+                MediaPlayer = VlcPlayer,
+                MinHeight = 200,
+                MinWidth = 200
+            };
         }
-
-        /// <summary>
-        /// The Camera class desctructor.
-        /// <para>This will stop the stream if it is playing and dispose of all LibVLC objects.</para>
-        /// </summary>
-        ~Camera()
-        {
-            Stop();
-            VlcPlayer.Dispose();
-            //Application.Current.Dispatcher.Invoke(VidView.Dispose, System.Windows.Threading.DispatcherPriority.Normal);
-        }
-
-        /// <summary>
-        /// Returns the view used to display the stream in the UI.
-        /// </summary>
-        /// <returns>A VideoView object.</returns>
-        //public VideoView VideoView()
-        //{
-        //    return VidView;
-        //}
 
         /// <summary>
         /// Starts the stream.

--- a/CameraViewer/Types/Camera.cs
+++ b/CameraViewer/Types/Camera.cs
@@ -1,5 +1,6 @@
 ﻿using LibVLCSharp.Shared;
 using LibVLCSharp.WPF;
+using System.Windows;
 
 namespace CameraViewer.Types
 {
@@ -21,12 +22,12 @@ namespace CameraViewer.Types
         /// <summary>
         /// The media player used by VLC to play the stream.
         /// </summary>
-        MediaPlayer VlcPlayer { get; }
+        public MediaPlayer VlcPlayer { get; }
 
         /// <summary>
         /// The view used to display the stream.
         /// </summary>
-        VideoView VidView { get; }
+        //VideoView VidView { get; }
 
         /// <summary>
         /// The Camera class constructor.
@@ -38,12 +39,12 @@ namespace CameraViewer.Types
             Name = name;
             ConnectionString = conString;
             VlcPlayer = new MediaPlayer(Globals.CameraLibVLC);
-            VidView = new VideoView()
-            {
-                MediaPlayer = VlcPlayer,
-                MinHeight = 200,
-                MinWidth = 200
-            };
+            //VidView = new VideoView()
+            //{
+            //    MediaPlayer = VlcPlayer,
+            //    MinHeight = 200,
+            //    MinWidth = 200
+            //};
         }
 
         /// <summary>
@@ -54,17 +55,17 @@ namespace CameraViewer.Types
         {
             Stop();
             VlcPlayer.Dispose();
-            VidView.Dispose();
+            //Application.Current.Dispatcher.Invoke(VidView.Dispose, System.Windows.Threading.DispatcherPriority.Normal);
         }
 
         /// <summary>
         /// Returns the view used to display the stream in the UI.
         /// </summary>
         /// <returns>A VideoView object.</returns>
-        public VideoView VideoView()
-        {
-            return VidView;
-        }
+        //public VideoView VideoView()
+        //{
+        //    return VidView;
+        //}
 
         /// <summary>
         /// Starts the stream.


### PR DESCRIPTION
This fixes a memory leak that occurs when refreshing the cameras.

The cause of the problem comes from the fact that the VLCPlayer and VideoView are disposed only when the Camera class' destructor is called. The destructor is called only when the garbage collector thinks it is time to do so. Sometimes the destructor is never even called, leaving the undisposed objects to unnecessarily fill up the system memory.

The solution is to move the responsibility of disposing the VLC objects to the programmer. Whenever the Camera object is about to be removed, the Dispose() methods of these VLC objects must be called explicitly.